### PR TITLE
Rename documentation target for automatic build

### DIFF
--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -51,7 +51,7 @@ doxygen reference
 
 xml contract : main.qbk : <dependency>reference ;
 
-boostbook boostdoc : contract
+boostbook boostrelease : contract
 :
     <location>html
     <xsl:param>boost.defaults=Boost


### PR DESCRIPTION
`boostdoc` is used for the combined documentation (e.g. at http://www.boost.org/doc/libs/1_65_1/doc/html/index.html), that doesn't appear to be what you want, so rename to `boostrelease` which is used for the standalone documentation build.