### PR TITLE
Fix validation error in explicit-failures-markup.xml

### DIFF
--- a/meta/explicit-failures-markup.xml
+++ b/meta/explicit-failures-markup.xml
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+
 <!--
 Copyright (C) 2008-2018 Lorenzo Caminiti
 Distributed under the Boost Software License, Version 1.0 (see accompanying
@@ -5,7 +7,6 @@ file LICENSE_1_0.txt or a copy at http://www.boost.org/LICENSE_1_0.txt).
 See: http://www.boost.org/doc/libs/release/libs/contract/doc/html/index.html
 -->
 
-<?xml version="1.0" encoding="utf-8"?>
 <explicit-failures-markup>
     <!-- contract -->
     <library name="contract">


### PR DESCRIPTION
Fix this validation error:

    $ xmllint --schema ~/boost/develop/status/explicit-failures.xsd explicit-failures-markup.xml
    explicit-failures-markup.xml:8: parser error : XML declaration allowed only at the start of the document
    <?xml version="1.0" encoding="utf-8"?>
    `     ^