### PR TITLE
Use uncaught_exceptions from Boost.Core to avoid C++17 warnings

### DIFF
--- a/include/boost/contract/detail/operation/constructor.hpp
+++ b/include/boost/contract/detail/operation/constructor.hpp
@@ -21,7 +21,7 @@
         !defined(BOOST_CONTRACT_NO_POSTCONDITIONS) || \
         !defined(BOOST_CONTRACT_NO_EXCEPTS)
     #include <boost/config.hpp>
-    #include <exception>
+    #include <boost/core/uncaught_exceptions.hpp>
 #endif
 
 namespace boost { namespace contract { namespace detail {
@@ -70,7 +70,7 @@ public:
 
             // If ctor body threw, no obj so check only static inv. Otherwise,
             // obj constructed so check static inv, non-static inv, and post.
-            if(std::uncaught_exception()) {
+            if(boost::core::uncaught_exceptions() > 0) {
                 #ifndef BOOST_CONTRACT_NO_EXIT_INVARIANTS
                     this->check_exit_static_inv();
                 #endif

--- a/include/boost/contract/detail/operation/destructor.hpp
+++ b/include/boost/contract/detail/operation/destructor.hpp
@@ -21,7 +21,7 @@
         !defined(BOOST_CONTRACT_NO_POSTCONDITIONS) || \
         !defined(BOOST_CONTRACT_NO_EXCEPTS)
     #include <boost/config.hpp>
-    #include <exception>
+    #include <boost/core/uncaught_exceptions.hpp>
 #endif
 
 namespace boost { namespace contract { namespace detail {
@@ -77,7 +77,7 @@ public:
             // language allows for that (even if in C++11 dtors declarations are
             // implicitly noexcept(true) unless specified otherwise) so this
             // library must handle such a case.
-            if(std::uncaught_exception()) {
+            if(boost::core::uncaught_exceptions() > 0) {
                 #ifndef BOOST_CONTRACT_NO_EXIT_INVARIANTS
                     this->check_exit_all_inv();
                 #endif

--- a/include/boost/contract/detail/operation/function.hpp
+++ b/include/boost/contract/detail/operation/function.hpp
@@ -19,7 +19,7 @@
 #if     !defined(BOOST_CONTRACT_NO_POSTCONDITIONS) || \
         !defined(BOOST_CONTRACT_NO_EXCEPTS)
     #include <boost/config.hpp>
-    #include <exception>
+    #include <boost/core/uncaught_exceptions.hpp>
 #endif
 
 namespace boost { namespace contract { namespace detail {
@@ -63,7 +63,7 @@ public:
                 checking k;
             #endif
             
-            if(std::uncaught_exception()) {
+            if(boost::core::uncaught_exceptions() > 0) {
                 #ifndef BOOST_CONTRACT_NO_EXCEPTS
                     this->check_except();
                 #endif

--- a/include/boost/contract/detail/operation/public_function.hpp
+++ b/include/boost/contract/detail/operation/public_function.hpp
@@ -24,10 +24,7 @@
         !defined(BOOST_CONTRACT_NO_POSTCONDITIONS) || \
         !defined(BOOST_CONTRACT_NO_EXCEPTS)
     #include <boost/config.hpp>
-#endif
-#if     !defined(BOOST_CONTRACT_NO_POSTCONDITIONS) || \
-        !defined(BOOST_CONTRACT_NO_EXCEPTS)
-    #include <exception>
+    #include <boost/core/uncaught_exceptions.hpp>
 #endif
 
 namespace boost { namespace contract { namespace detail {
@@ -113,7 +110,7 @@ private:
                 #ifndef BOOST_CONTRACT_NO_EXIT_INVARIANTS
                     this->check_subcontracted_exit_inv();
                 #endif
-                if(std::uncaught_exception()) {
+                if(boost::core::uncaught_exceptions() > 0) {
                     #ifndef BOOST_CONTRACT_NO_EXCEPTS
                         this->check_subcontracted_except();
                     #endif
@@ -141,7 +138,7 @@ public:
                 #ifndef BOOST_CONTRACT_NO_EXIT_INVARIANTS
                     this->check_subcontracted_exit_inv();
                 #endif
-                if(std::uncaught_exception()) {
+                if(boost::core::uncaught_exceptions() > 0) {
                     #ifndef BOOST_CONTRACT_NO_EXCEPTS
                         this->check_subcontracted_except();
                     #endif

--- a/include/boost/contract/detail/operation/static_public_function.hpp
+++ b/include/boost/contract/detail/operation/static_public_function.hpp
@@ -22,7 +22,7 @@
         !defined(BOOST_CONTRACT_NO_POSTCONDITIONS) || \
         !defined(BOOST_CONTRACT_NO_EXCEPTS)
     #include <boost/config.hpp>
-    #include <exception>
+    #include <boost/core/uncaught_exceptions.hpp>
 #endif
 
 namespace boost { namespace contract { namespace detail {
@@ -84,7 +84,7 @@ public:
             #ifndef BOOST_CONTRACT_NO_EXIT_INVARIANTS
                 this->check_exit_static_inv();
             #endif
-            if(std::uncaught_exception()) {
+            if(boost::core::uncaught_exceptions() > 0) {
                 #ifndef BOOST_CONTRACT_NO_EXCEPTS
                     this->check_except();
                 #endif


### PR DESCRIPTION
In C++17, `std::uncaught_exception` is deprecated in favor of `std::uncaught_exceptions`. Use portable `uncaught_exceptions` implementation from Boost.Core, which is also available for C++03.

This fixes gcc 8 warnings about using deprecated features in C++17 mode.
