### PR TITLE
Remove linking with Boost.System

### DIFF
--- a/build/boost_contract_build.jam
+++ b/build/boost_contract_build.jam
@@ -68,7 +68,6 @@ module boost_contract_build {
 rule project_requirements ( subdir ) {
     return
         <bc_hdr>lib:<library>../build//boost_contract
-        <bc_hdr>only:<library>/boost/system//boost_system
         <include>$(subdir)
     ;
 }


### PR DESCRIPTION
Since Boost.System is header-only now, no need to link with the library.